### PR TITLE
Fix FIFO path on newer Weechat versions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,13 @@ The following list shows various ways to use InWee from the shell.
      are ignored. Therefore, `#` can be used to begin single line
      comments.
 
+  7. To use a custom FIFO path with Weechat.
+
+     `echo "hello world" | inwee --fifo-path "$HOME/.weechat/weechat_fifo"`
+
+     This will make inwee use a custom FIFO path to communicate with
+     Weechat.
+
 ### Using from WeeChat ###
 From WeeChat's perspective, InWee is an external command that can be
 invoked with the `inwee` command. WeeChat's `/exec` command executes

--- a/inwee
+++ b/inwee
@@ -51,7 +51,7 @@ main()
 {
     parse_arguments "$@"
 
-    # Find FIFO path via the -fp|--fifo-path argument.
+    # Find FIFO path via the -f|--fifo argument.
     if [ -e "$fifo_path" ]; then
         debug_output "Found FIFO socket on custom argument."
         fifo="$fifo_path"
@@ -130,7 +130,7 @@ parse_arguments()
                 buffer="$2"
                 shift 2
                 ;;
-            -fp | --fifo-path)
+            -f | --fifo)
                 [ -n "$2" ] || quit \""$1"\" must be followed by a path to the FIFO socket.
                 fifo_path="$2"
                 ;;

--- a/inwee
+++ b/inwee
@@ -51,18 +51,37 @@ main()
 {
     parse_arguments "$@"
 
-    # Find FIFO pipe.
+    # Find FIFO path via the -fp|--fifo-path argument.
+    if [ -e "$fifo_path" ]; then
+        debug_output "Found FIFO socket on custom argument."
+        fifo="$fifo_path"
+    else
+        debug_output "Could not find FIFO socket on custom argument."
+    fi
+
+    # Find FIFO pipe via the PID method.
     for f in ~/.weechat/weechat_fifo_*
     do
-        if [ "$f" != ~/.weechat/weechat_fifo_"*" ]
-        then
+        if [ "$f" != ~/.weechat/weechat_fifo_"*" ]; then
             fifo="$f"
             break
+        else
+            debug_output "Could not find FIFO socket via PID method."
         fi
     done
 
-    if [ -z "$fifo" ]
-    then
+    # If we still don't have the FIFO path, then we should try it with
+    # the default path for Weechat 1.7.
+    if [ -z "$fifo" ]; then
+        if [ -e "$HOME/.weechat/weechat_fifo" ]; then
+            debug_output "Found FIFO socket via Weechat 1.7 default path."
+            fifo="$HOME/.weechat/weechat_fifo"
+        else
+            debug_output "Could not find FIFO socket via Weechat 1.7 default path."
+        fi
+    fi
+
+    if [ -z "$fifo" ]; then
         quit Could not find Weechat FIFO pipe.
     fi
 
@@ -110,6 +129,10 @@ parse_arguments()
                 [ -n "$2" ] || quit \""$1"\" must be followed by buffer name.
                 buffer="$2"
                 shift 2
+                ;;
+            -fp | --fifo-path)
+                [ -n "$2" ] || quit \""$1"\" must be followed by a path to the FIFO socket.
+                fifo_path="$2"
                 ;;
             -d | --debug)
                 debug=yes
@@ -179,10 +202,11 @@ specified or if it is specified as '-', i.e. a hyphen, then text and
 commands are read from standard input.
 
 Options:
-  -b, --buffer BUFFER  Buffer to send text or command to.
-  -d, --debug          Show diagnostic information.
-  -h, --help           Show this help and exit.
-  -v, --version        Show version and exit.
+  -b, --buffer BUFFER   Buffer to send text or command to.
+  -fp, --fifo-path PATH FIFO Path to send commands to.
+  -d, --debug           Show diagnostic information.
+  -h, --help            Show this help and exit.
+  -v, --version         Show version and exit.
 
 Report bugs to <$SUPPORT_URL>."
 }

--- a/inwee
+++ b/inwee
@@ -60,7 +60,7 @@ main()
     fi
 
     # Find FIFO pipe via the PID method.
-    for f in ~/.weechat/weechat_fifo_*
+    for f in ~/.weechat/weechat_fifo*
     do
         if [ "$f" != ~/.weechat/weechat_fifo_"*" ]; then
             fifo="$f"
@@ -69,17 +69,6 @@ main()
             debug_output "Could not find FIFO socket via PID method."
         fi
     done
-
-    # If we still don't have the FIFO path, then we should try it with
-    # the default path for Weechat 1.7.
-    if [ -z "$fifo" ]; then
-        if [ -e "$HOME/.weechat/weechat_fifo" ]; then
-            debug_output "Found FIFO socket via Weechat 1.7 default path."
-            fifo="$HOME/.weechat/weechat_fifo"
-        else
-            debug_output "Could not find FIFO socket via Weechat 1.7 default path."
-        fi
-    fi
 
     if [ -z "$fifo" ]; then
         quit Could not find Weechat FIFO pipe.


### PR DESCRIPTION
This PR fixes #1, and implements systematic tries of the Weechat FIFO path, as described in commit df0af77 and updates the README to reflect that.